### PR TITLE
fix(layout): Work around Chromium background compositing artifact

### DIFF
--- a/src/layouts/AlbumLayout.astro
+++ b/src/layouts/AlbumLayout.astro
@@ -15,6 +15,7 @@ const { album } = Astro.props;
   html {
     background-color: hsl(var(--background));
     color: hsl(var(--foreground));
+    min-height: 100%;
   }
   body {
     font-feature-settings:
@@ -24,7 +25,16 @@ const { album } = Astro.props;
     padding: 20px;
     min-width: 320px;
     overflow-wrap: break-word;
+    overscroll-behavior: none;
     scroll-behavior: smooth;
+  }
+  body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    background-color: hsl(var(--background));
+    pointer-events: none;
   }
 </style>
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -20,9 +20,9 @@ const { title, description, image } = Astro.props.frontmatter || Astro.props;
   html {
     background-color: hsl(var(--background));
     color: hsl(var(--foreground));
+    min-height: 100%;
   }
   body {
-    background-color: hsl(var(--background));
     font-feature-settings:
       'rlig' 1,
       'calt' 1;
@@ -30,9 +30,18 @@ const { title, description, image } = Astro.props.frontmatter || Astro.props;
     padding: 20px;
     max-width: 70ch;
     min-width: 320px;
-    min-height: 100dvh;
+    min-height: 100vh;
     overflow-wrap: break-word;
+    overscroll-behavior: none;
     scroll-behavior: smooth;
+  }
+  body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    background-color: hsl(var(--background));
+    pointer-events: none;
   }
 </style>
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -42,6 +42,7 @@
 }
 
 :root {
+  color-scheme: light;
   --background: 0 0% 100%;
   --foreground: 0 0% 22%;
 
@@ -74,6 +75,7 @@
 }
 
 .dark {
+  color-scheme: dark;
   --background: 0 0% 10%;
   --foreground: 0 0% 89%;
 


### PR DESCRIPTION
## Context

A lighter band appeared at the bottom of the page in Chromium
browsers at viewport widths of 705px and below. The root cause
is a Chromium GPU compositing quirk: overlapping elements with
identical `background-color` values render with subtle shade
differences at layer boundaries.

## Solution

Replace the overlapping `background-color` on `html` and `body`
with a single `body::before` fixed viewport backdrop
(`position: fixed; inset: 0; z-index: -1`). This ensures one
consistent background layer across the entire viewport,
eliminating compositing seams.

Supporting changes:
- Add `color-scheme: light`/`dark` to `:root`/`.dark`
- Add `overscroll-behavior: none` on `body`
- Add `min-height: 100%` on `html`

## Testing plan

- Verified in Chrome DevTools responsive mode at widths from
  320px to 1728px — no visible band
- Confirmed uniform background in both light and dark modes
- Tested on Firefox/Safari (no regressions)

## Security

N/A