### PR TITLE
perf(photos): Optimize LCP images, add preconnect and a11y fix

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -30,6 +30,7 @@ const socialImageURL = new URL(image, Astro.url);
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+<link rel="preconnect" href="https://photos.salolivares.com" />
 <meta name="generator" content={Astro.generator} />
 <link rel="sitemap" href="/sitemap-index.xml" />
 

--- a/src/components/FeaturedImage.astro
+++ b/src/components/FeaturedImage.astro
@@ -15,7 +15,7 @@ const name = image.name ?? 'Untitled';
 ---
 
 <div class:list={[className, 'flex flex-col']}>
-  <RemoteImage src={image.src} alt={name} />
+  <RemoteImage src={image.src} alt={name} loading="eager" fetchpriority="high" />
   <div class="mt-2 flex flex-col justify-end">
     <div class="text-right text-base font-semibold">{name}</div>
   </div>

--- a/src/components/RemoteImage.astro
+++ b/src/components/RemoteImage.astro
@@ -5,27 +5,34 @@ interface Props {
   src: string;
   alt?: string;
   class?: string;
+  loading?: 'lazy' | 'eager';
+  fetchpriority?: 'high' | 'low' | 'auto';
   [index: string]: any;
 }
 
 const host = 'https://photos.salolivares.com';
-const { src: propSrc, alt = '', class: className, ...rest } = Astro.props;
+const { src: propSrc, alt = '', class: className, loading = 'lazy', fetchpriority, ...rest } = Astro.props;
 const src = encodeURIComponent(propSrc);
+const sizes = '(max-width: 1280px) 100vw, 1280px';
 ---
 
 <picture class={className} {...rest}>
   <source
     srcset={`${host}/${src}_1280.webp 1280w, ${host}/${src}_2880.webp 2880w`}
+    sizes={sizes}
     type="image/webp"
   />
   <source
     srcset={`${host}/${src}_1280.jpg 1280w, ${host}/${src}_2880.jpg 2880w`}
+    sizes={sizes}
     type="image/jpeg"
   />
   <img
     alt={alt}
-    loading="lazy"
+    loading={loading}
+    fetchpriority={fetchpriority}
     src={`${host}/${src}_1280.jpg`}
+    sizes={sizes}
     width="1280"
     style="height: auto; max-height: 80vh; width: auto; max-width: 100%;"
   />

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -2,7 +2,7 @@
 import { Sun, Moon } from '@lucide/astro';
 ---
 
-<button id="themeToggle" class="hover:opacity-50 dark:hover:opacity-75">
+<button id="themeToggle" aria-label="Toggle theme" class="hover:opacity-50 dark:hover:opacity-75">
   <Sun class="sun" />
   <Moon class="moon" />
 </button>

--- a/src/pages/photos/[album].astro
+++ b/src/pages/photos/[album].astro
@@ -25,9 +25,14 @@ const { images } = album.data;
 <AlbumLayout album={album}>
   <div class="flex flex-col items-center">
     {
-      images.map((image) => (
+      images.map((image, i) => (
         <div class="flex min-h-screen max-w-screen-lg flex-col justify-center">
-          <RemoteImage src={`${album.id}/${image.id}`} alt={image.name ?? 'Untitled'} />
+          <RemoteImage
+            src={`${album.id}/${image.id}`}
+            alt={image.name ?? 'Untitled'}
+            loading={i === 0 ? 'eager' : 'lazy'}
+            fetchpriority={i === 0 ? 'high' : undefined}
+          />
           <div class="mt-3 text-right text-base font-semibold">{image.name ?? 'Untitled'}</div>
         </div>
       ))


### PR DESCRIPTION
## Context

Chrome DevTools performance traces showed photo pages had LCP images
with `loading="lazy"` and no `fetchpriority`, causing the browser
to deprioritize the most important visible image. CloudFront images
also lacked a preconnect hint, and the theme toggle button had no
accessible name (Lighthouse accessibility score: 90).

## Solution

- Add `loading`, `fetchpriority`, and `sizes` props to
  `RemoteImage.astro`; first image on album pages and featured
  image on `/photos` now load eagerly with high priority
- Add `<link rel="preconnect">` for `photos.salolivares.com` CDN
- Add `aria-label="Toggle theme"` to the theme toggle button

## Testing plan

- `pnpm build` passes
- Chrome DevTools trace confirms LCP image no longer lazy-loaded
- Lighthouse accessibility score should reach 100