### PR TITLE
feat(og): Pass articleDate to BaseHead for blog posts

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -12,6 +12,7 @@ export interface Props {
   description?: string;
   image?: string;
   articleDate?: string;
+  articleUpdatedDate?: string;
 }
 
 const {
@@ -19,6 +20,7 @@ const {
   description = config.description,
   image = 'images/social-banner.png',
   articleDate,
+  articleUpdatedDate,
 } = Astro.props;
 
 const title = propTitle ? propTitle : config.title;
@@ -54,6 +56,9 @@ const socialImageURL = new URL(image, Astro.url);
     <>
       <meta property="article:author" content={config.author} />
       <meta property="article:published_time" content={articleDate} />
+      {articleUpdatedDate && (
+        <meta property="article:modified_time" content={articleUpdatedDate} />
+      )}
     </>
   )
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,13 +7,15 @@ interface Props {
   title?: string;
   description?: string;
   image?: string;
+  articleDate?: string;
+  articleUpdatedDate?: string;
   // https://docs.astro.build/en/core-concepts/layouts/#using-one-layout-for-md-mdx-and-astro
   frontmatter?: MarkdownLayoutProps<Props>['frontmatter'];
 }
 
 const isMarkdown = Astro.props.frontmatter !== undefined;
 
-const { title, description, image } = Astro.props.frontmatter || Astro.props;
+const { title, description, image, articleDate, articleUpdatedDate } = Astro.props.frontmatter || Astro.props;
 ---
 
 <style>
@@ -66,7 +68,7 @@ const { title, description, image } = Astro.props.frontmatter || Astro.props;
 
       window.localStorage.setItem('theme', theme);
     </script>
-    <BaseHead title={title} description={description} image={image} />
+    <BaseHead title={title} description={description} image={image} articleDate={articleDate} articleUpdatedDate={articleUpdatedDate} />
   </head>
   <body>
     <Header />

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -12,7 +12,7 @@ const { title, subtitle, description, heroImage, heroImageAlt = null, pubDate, u
 const ogImage = `/og-image/${id}.png`;
 ---
 
-<BaseLayout title={title} description={description} image={ogImage}>
+<BaseLayout title={title} description={description} image={ogImage} articleDate={pubDate.toISOString()} articleUpdatedDate={updatedDate?.toISOString()}>
   <article class="prose prose-custom dark:prose-invert mb-80">
     {heroImage && <Image width={720} height={360} src={heroImage} alt={heroImageAlt} />}
     <h1 class="mb-1">{title}</h1>


### PR DESCRIPTION
## Context

Blog posts have `pubDate` and `updatedDate` fields but `BaseHead`
never receives them. This means all pages render as
`og:type: website` instead of `article`, and blog posts lack
`article:published_time` / `article:modified_time` meta tags.

## Solution

Thread `pubDate` and `updatedDate` from `BlogPostLayout` through
`BaseLayout` to `BaseHead` as ISO 8601 strings. Blog posts now
emit `og:type=article` with proper article metadata per the
Open Graph protocol spec (https://ogp.me/).

## Testing plan

- `pnpm build` passes clean
- Verified blog post HTML contains `og:type=article`,
  `article:published_time`, and `article:author`
- Verified homepage still renders `og:type=website`