### PR TITLE
feat(blog): Add giscus comments with theme sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,9 @@
+## Development workflow
+
+- Run the dev server (`pnpm dev`) and use Chrome DevTools MCP to visually verify changes in the browser
+- After making UI/styling changes, take screenshots to confirm the result looks correct
+- Use `pnpm build` to check for build errors before considering work complete
+
 ## Pages CMS
 
 Configured in `.pages.yml` at repo root. Docs: https://pagescms.org/docs/

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -43,6 +43,7 @@ import { Sun, Moon } from '@lucide/astro';
 
     const isDark = element.classList.contains('dark');
     localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    document.dispatchEvent(new CustomEvent('theme-change', { detail: { theme: isDark ? 'dark' : 'light' } }));
   };
 
   document.getElementById('themeToggle').addEventListener('click', handleToggleClick);

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -28,6 +28,7 @@ const blog = defineCollection({
       heroImage: image().optional(),
       heroImageAlt: z.string().optional(),
       published: z.boolean().default(false),
+      comments: z.boolean().default(true),
     }),
 });
 

--- a/src/content/blog/my-rating-system.md
+++ b/src/content/blog/my-rating-system.md
@@ -4,6 +4,7 @@ subtitle: 'A *highly* objective rating system for anything and everything.'
 description: 'A highly objective rating system for anything and everything.'
 pubDate: '2024-01-03'
 published: true
+comments: false
 ---
 
 Did I say objective? I meant _highly_ subjective. For my own sanity I needed a consistent way

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -8,12 +8,12 @@ import { CornerDownLeft } from '@lucide/astro';
 type Props = CollectionEntry<'blog'>;
 
 const { data, id } = Astro.props;
-const { title, subtitle, description, heroImage, heroImageAlt = null, pubDate, updatedDate } = data;
+const { title, subtitle, description, heroImage, heroImageAlt = null, pubDate, updatedDate, comments = true } = data;
 const ogImage = `/og-image/${id}.png`;
 ---
 
 <BaseLayout title={title} description={description} image={ogImage} articleDate={pubDate.toISOString()} articleUpdatedDate={updatedDate?.toISOString()}>
-  <article class="prose prose-custom dark:prose-invert mb-80">
+  <article class="prose prose-custom dark:prose-invert">
     {heroImage && <Image width={720} height={360} src={heroImage} alt={heroImageAlt} />}
     <h1 class="mb-1">{title}</h1>
     {subtitle && <div class="text-muted-foreground mt-1 mb-3 italic">{subtitle}</div>}
@@ -27,17 +27,57 @@ const ogImage = `/og-image/${id}.png`;
     }
     <hr class="not-prose my-5 border-(--tw-prose-hr)" />
     <slot />
-    <div class="flex flex-col items-center">
-      <div class="my-24">
-        <a
-          href="/blog"
-          data-astro-prefetch="viewport"
-          aria-label="Back to posts"
-          class="rounded-full p-6 transition-colors duration-200 hover:opacity-50 dark:hover:opacity-75"
-        >
-          <CornerDownLeft />
-        </a>
-      </div>
-    </div>
   </article>
+
+  {comments && (
+    <section class="giscus mt-16 mb-16"></section>
+
+    <script is:inline>
+      (function () {
+        var container = document.querySelector('.giscus');
+        if (!container) return;
+        var theme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+        var s = document.createElement('script');
+        s.src = 'https://giscus.app/client.js';
+        s.setAttribute('data-repo', 'salolivares/salolivares.com');
+        s.setAttribute('data-repo-id', 'MDEwOlJlcG9zaXRvcnkzMDMxODYwMTg=');
+        s.setAttribute('data-category', 'Announcements');
+        s.setAttribute('data-category-id', 'DIC_kwDOEhJAYs4C64i0');
+        s.setAttribute('data-mapping', 'pathname');
+        s.setAttribute('data-strict', '0');
+        s.setAttribute('data-reactions-enabled', '0');
+        s.setAttribute('data-emit-metadata', '0');
+        s.setAttribute('data-input-position', 'top');
+        s.setAttribute('data-theme', theme);
+        s.setAttribute('data-lang', 'en');
+        s.setAttribute('data-loading', 'lazy');
+        s.setAttribute('crossorigin', 'anonymous');
+        s.async = true;
+        container.appendChild(s);
+
+        document.addEventListener('theme-change', function (e) {
+          var iframe = document.querySelector('iframe.giscus-frame');
+          if (iframe) {
+            iframe.contentWindow.postMessage(
+              { giscus: { setConfig: { theme: e.detail.theme } } },
+              'https://giscus.app'
+            );
+          }
+        });
+      })();
+    </script>
+  )}
+
+  <div class="flex flex-col items-center">
+    <div class="my-24">
+      <a
+        href="/blog"
+        data-astro-prefetch="viewport"
+        aria-label="Back to posts"
+        class="rounded-full p-6 transition-colors duration-200 hover:opacity-50 dark:hover:opacity-75"
+      >
+        <CornerDownLeft />
+      </a>
+    </div>
+  </div>
 </BaseLayout>


### PR DESCRIPTION
Embed giscus on blog posts via a dynamically created script
element so `data-theme` is set from the site's current theme
at runtime (not OS preference). Theme toggle dispatches a
custom `theme-change` event, and the giscus iframe is updated
via `postMessage`. A `comments` frontmatter field (defaults to
`true`) allows disabling comments per-post.