### PR TITLE
feat(style): Restyle site with mono palette, cards, and bracket UI

### DIFF
--- a/src/components/Badge.astro
+++ b/src/components/Badge.astro
@@ -2,34 +2,33 @@
 import { cva } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
-const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
-  {
-    variants: {
-      variant: {
-        default: 'border-transparent bg-primary text-primary-foreground hover:bg-primary/80',
-        secondary:
-          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        destructive:
-          'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
-        outline: 'text-foreground',
-      },
-    },
-    defaultVariants: {
-      variant: 'default',
+const base =
+  'inline-flex items-center border px-2 py-0.5 text-xs font-semibold uppercase tracking-wider transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2';
+
+const badgeVariants = cva('', {
+  variants: {
+    variant: {
+      default: `${base} border-transparent bg-primary text-primary-foreground hover:bg-primary/80`,
+      secondary: `${base} border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80`,
+      destructive: `${base} border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80`,
+      outline: `${base} border-border text-foreground`,
+      bracket: 'text-accent-blue',
     },
   },
-);
+  defaultVariants: {
+    variant: 'default',
+  },
+});
 
 interface Props {
   class?: string;
-  variant?: 'default' | 'secondary' | 'destructive' | 'outline';
+  variant?: 'default' | 'secondary' | 'destructive' | 'outline' | 'bracket';
   [key: string]: unknown;
 }
 
-const { class: className, variant, ...props } = Astro.props;
+const { class: className, variant = 'default', ...props } = Astro.props;
 ---
 
-<div class={cn(badgeVariants({ variant: variant }), className)} {...props}>
-  <slot />
-</div>
+<span class={cn(badgeVariants({ variant }), className)} {...props}>
+  {variant === 'bracket' && '['}<slot />{variant === 'bracket' && ']'}
+</span>

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -2,14 +2,15 @@
 import type { HTMLAttributes } from 'astro/types';
 
 interface Props extends HTMLAttributes<'div'> {
+  as?: 'div' | 'article' | 'section' | 'aside' | 'nav';
   shadow?: boolean;
   padded?: boolean;
 }
 
-const { class: className, shadow = true, padded = true, ...rest } = Astro.props;
+const { as: Tag = 'div', class: className, shadow = true, padded = true, ...rest } = Astro.props;
 ---
 
-<div
+<Tag
   class:list={[
     'border-border bg-card border',
     padded && 'p-5',
@@ -19,4 +20,4 @@ const { class: className, shadow = true, padded = true, ...rest } = Astro.props;
   {...rest}
 >
   <slot />
-</div>
+</Tag>

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -1,0 +1,22 @@
+---
+import type { HTMLAttributes } from 'astro/types';
+
+interface Props extends HTMLAttributes<'div'> {
+  shadow?: boolean;
+  padded?: boolean;
+}
+
+const { class: className, shadow = true, padded = true, ...rest } = Astro.props;
+---
+
+<div
+  class:list={[
+    'border-border bg-card border',
+    padded && 'p-5',
+    shadow && 'shadow-card',
+    className,
+  ]}
+  {...rest}
+>
+  <slot />
+</div>

--- a/src/components/FeedItem.astro
+++ b/src/components/FeedItem.astro
@@ -1,5 +1,6 @@
 ---
 import Badge from './Badge.astro';
+import Card from './Card.astro';
 import { relativeTime } from '@/lib/relative-time';
 
 interface Props {
@@ -11,20 +12,20 @@ interface Props {
 const { pubDate, type, permalink } = Astro.props;
 ---
 
-<article class="border-b border-border py-5">
-  <div class="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
-    <a href={permalink} class="decoration-muted-foreground/50 hover:decoration-foreground">
+<Card as="article" class="mb-5">
+  <div class="text-muted-foreground mb-3 flex items-center gap-2 text-sm">
+    <a href={permalink} class="decoration-muted-foreground/50 hover:text-accent-blue">
       <time datetime={pubDate.toISOString()} data-relative>
         {relativeTime(pubDate)}
       </time>
     </a>
     <span>&middot;</span>
-    <Badge variant="outline" class="px-1.5 py-0 text-[10px]">{type}</Badge>
+    <Badge variant="bracket">{type}</Badge>
   </div>
   <div class="prose prose-sm prose-custom dark:prose-invert max-w-none [&>p:first-child]:mt-0">
     <slot />
   </div>
-</article>
+</Card>
 
 <script>
   function relativeTime(date: Date): string {

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,20 +1,14 @@
 ---
-import { config } from '@/site.config';
 import HeaderLink from './HeaderLink.astro';
 import ThemeToggle from './ThemeToggle.astro';
-
-const title = config.title;
 ---
 
-<header class="mb-10 sm:mt-5">
-  <div class="mb-1 text-2xl font-bold lowercase">
-    {title}
-  </div>
-  <nav class="flex justify-between">
-    <div class="flex gap-3">
-      <HeaderLink href="/">Home</HeaderLink>
-      <HeaderLink href="/blog">Blog</HeaderLink>
-      <HeaderLink href="/photos">Photos</HeaderLink>
+<header class="mt-5 mb-10">
+  <nav class="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+    <div class="flex flex-wrap gap-x-3 gap-y-1">
+      <HeaderLink href="/" label="~" />
+      <HeaderLink href="/blog" label="~/blog" />
+      <HeaderLink href="/photos" label="~/photos" />
     </div>
     <ThemeToggle />
   </nav>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,15 +1,18 @@
 ---
+import Card from './Card.astro';
 import HeaderLink from './HeaderLink.astro';
 import ThemeToggle from './ThemeToggle.astro';
 ---
 
 <header class="mt-5 mb-10">
-  <nav class="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
-    <div class="flex flex-wrap gap-x-3 gap-y-1">
-      <HeaderLink href="/" label="~" />
-      <HeaderLink href="/blog" label="~/blog" />
-      <HeaderLink href="/photos" label="~/photos" />
-    </div>
-    <ThemeToggle />
-  </nav>
+  <Card padded={false}>
+    <nav class="flex items-center justify-between gap-4 px-5 py-3">
+      <div class="flex flex-wrap gap-x-4 gap-y-1">
+        <HeaderLink href="/" label="~" />
+        <HeaderLink href="/blog" label="~/blog" />
+        <HeaderLink href="/photos" label="~/photos" />
+      </div>
+      <ThemeToggle />
+    </nav>
+  </Card>
 </header>

--- a/src/components/HeaderLink.astro
+++ b/src/components/HeaderLink.astro
@@ -1,16 +1,31 @@
 ---
 import type { HTMLAttributes } from 'astro/types';
 
-type Props = HTMLAttributes<'a'>;
+type Props = HTMLAttributes<'a'> & {
+  href: string;
+  label: string;
+};
 
-const { href, class: className, ...props } = Astro.props;
+const { href, label, class: className, ...props } = Astro.props;
+
+const pathname = Astro.url.pathname.replace(/\/+$/, '') || '/';
+const normalizedHref = href.replace(/\/+$/, '') || '/';
+const isActive =
+  normalizedHref === '/'
+    ? pathname === '/'
+    : pathname === normalizedHref || pathname.startsWith(normalizedHref + '/');
 ---
 
 <a
   href={href}
-  class:list={[className, 'no-underline underline-offset-4 hover:underline hover:decoration-solid']}
+  aria-current={isActive ? 'page' : undefined}
+  class:list={[
+    'hover:text-accent-blue no-underline',
+    isActive && 'text-accent-blue',
+    className,
+  ]}
   data-astro-prefetch="viewport"
   {...props}
 >
-  <slot />
+  [{label}]
 </a>

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -11,21 +11,24 @@ const { prevUrl, nextUrl, currentPage, lastPage } = Astro.props;
 
 {
   lastPage > 1 && (
-    <nav class="flex items-center justify-between border-t border-border pt-5" aria-label="Pagination">
+    <nav
+      class="border-border mt-8 flex items-center justify-between border-t pt-5 text-sm"
+      aria-label="Pagination"
+    >
       <div>
         {prevUrl && (
-          <a href={prevUrl} class="text-sm" data-astro-prefetch>
-            &larr; Newer
+          <a href={prevUrl} class="hover:text-accent-blue no-underline" data-astro-prefetch>
+            [&larr; newer]
           </a>
         )}
       </div>
-      <span class="text-sm text-muted-foreground">
+      <span class="text-muted-foreground">
         {currentPage} / {lastPage}
       </span>
       <div>
         {nextUrl && (
-          <a href={nextUrl} class="text-sm" data-astro-prefetch>
-            Older &rarr;
+          <a href={nextUrl} class="hover:text-accent-blue no-underline" data-astro-prefetch>
+            [older &rarr;]
           </a>
         )}
       </div>

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -3,7 +3,6 @@ import type { CollectionEntry } from 'astro:content';
 import FormattedDate from '../components/FormattedDate.astro';
 import BaseLayout from './BaseLayout.astro';
 import { Image } from 'astro:assets';
-import { CornerDownLeft } from '@lucide/astro';
 
 type Props = CollectionEntry<'blog'>;
 
@@ -70,16 +69,13 @@ const ogImage = `/og-image/${id}.png`;
     </script>
   )}
 
-  <div class="flex flex-col items-center">
-    <div class="my-24">
-      <a
-        href="/blog"
-        data-astro-prefetch="viewport"
-        aria-label="Back to posts"
-        class="rounded-full p-6 transition-colors duration-200 hover:opacity-50 dark:hover:opacity-75"
-      >
-        <CornerDownLeft />
-      </a>
-    </div>
+  <div class="mt-24 flex flex-col items-center">
+    <a
+      href="/blog"
+      data-astro-prefetch="viewport"
+      class="hover:text-accent-blue no-underline"
+    >
+      [&larr; back to posts]
+    </a>
   </div>
 </BaseLayout>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,18 +1,19 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import Card from '../components/Card.astro';
 import { Image } from 'astro:assets';
 import dog from '../assets/images/dog.jpeg';
 ---
 
 <BaseLayout>
-  <h1>Welp, that's ruff.</h1>
-  <div class="mb-5 mt-1 italic text-muted-foreground">
-    My dog personally apologizes for not finding the page you were looking for.
-  </div>
-  <div class="mb-80 p-5">
+  <Card class="mt-10 mb-40">
+    <h1>Welp, that's ruff.</h1>
+    <div class="text-muted-foreground mt-1 mb-5 italic">
+      My dog personally apologizes for not finding the page you were looking for.
+    </div>
     <Image
       src={dog}
       alt="A picture of my dog, a white bichon frise, looking at the camera suspiciously."
     />
-  </div>
+  </Card>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import Card from '../components/Card.astro';
 ---
 
 <BaseLayout>
@@ -14,13 +15,36 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     Checkout my <a href="/bestof" data-astro-prefetch>collection of quotes</a>
     I've collected over the years.
   </p>
-  <p>
-    You can find me on:
-    <ul class="mt-0">
-      <li><a href="https://github.com/salolivares">GitHub</a></li>
-      <li><a href="https://twitter.com/0x102c">Twitter</a></li>
-      <li><a href="https://www.linkedin.com/in/salolivares/">LinkedIn</a></li>
-      <li><a href="https://bsky.app/profile/0x102c.bsky.social">Bluesky</a></li>
-    </ul>
-  </p>
+
+  <Card class="mt-10">
+    <h2 class="text-muted-foreground mb-4 border-b pb-2 text-sm font-normal tracking-wider uppercase">
+      Links
+    </h2>
+    <dl class="grid grid-cols-[auto_1fr] gap-x-6 gap-y-1">
+      <dt class="text-muted-foreground">GitHub</dt>
+      <dd>
+        <a href="https://github.com/salolivares" class="hover:text-accent-blue no-underline">
+          [salolivares]
+        </a>
+      </dd>
+      <dt class="text-muted-foreground">Twitter</dt>
+      <dd>
+        <a href="https://twitter.com/0x102c" class="hover:text-accent-blue no-underline">
+          [0x102c]
+        </a>
+      </dd>
+      <dt class="text-muted-foreground">LinkedIn</dt>
+      <dd>
+        <a href="https://www.linkedin.com/in/salolivares/" class="hover:text-accent-blue no-underline">
+          [salolivares]
+        </a>
+      </dd>
+      <dt class="text-muted-foreground">Bluesky</dt>
+      <dd>
+        <a href="https://bsky.app/profile/0x102c.bsky.social" class="hover:text-accent-blue no-underline">
+          [0x102c.bsky.social]
+        </a>
+      </dd>
+    </dl>
+  </Card>
 </BaseLayout>

--- a/src/pages/photos/[album].astro
+++ b/src/pages/photos/[album].astro
@@ -3,7 +3,6 @@ import RemoteImage from '@/components/RemoteImage.astro';
 import AlbumLayout from '@/layouts/AlbumLayout.astro';
 import type { GetStaticPaths, InferGetStaticPropsType } from 'astro';
 import { getCollection } from 'astro:content';
-import { CornerDownLeft } from '@lucide/astro';
 
 export const getStaticPaths = (async () => {
   const albums = await getCollection('photos');
@@ -50,10 +49,9 @@ const { images } = album.data;
       <a
         href="/photos"
         data-astro-prefetch="viewport"
-        aria-label="Back to albums"
-        class="rounded-full p-6 transition-colors duration-200 hover:opacity-50 dark:hover:opacity-75"
+        class="hover:text-accent-blue no-underline"
       >
-        <CornerDownLeft />
+        [&larr; back to albums]
       </a>
     </div>
   </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -122,30 +122,42 @@
   --shadow: 0 0% 20%;
 }
 
+@utility active-item {
+  border-left: 2px solid hsl(var(--accent-blue));
+  padding-left: 0.75rem;
+}
+
 @utility prose-custom {
   --tw-prose-body: hsl(var(--foreground));
   --tw-prose-headings: hsl(var(--foreground));
   --tw-prose-quotes: hsl(var(--foreground));
   --tw-prose-code: hsl(var(--foreground));
   --tw-prose-links: hsl(var(--foreground));
+  --tw-prose-bold: hsl(var(--foreground));
+  --tw-prose-bullets: hsl(var(--muted-foreground));
+  --tw-prose-counters: hsl(var(--muted-foreground));
+  --tw-prose-hr: hsl(var(--border));
 
   --tw-prose-invert-body: hsl(var(--foreground));
   --tw-prose-invert-headings: hsl(var(--foreground));
   --tw-prose-invert-quotes: hsl(var(--foreground));
   --tw-prose-invert-code: hsl(var(--foreground));
   --tw-prose-invert-links: hsl(var(--foreground));
+  --tw-prose-invert-bold: hsl(var(--foreground));
+  --tw-prose-invert-bullets: hsl(var(--muted-foreground));
+  --tw-prose-invert-counters: hsl(var(--muted-foreground));
+  --tw-prose-invert-hr: hsl(var(--border));
 
   & :where(h1) {
-    font-size: 1.25rem;
-    line-height: 1.75rem;
+    font-size: 1.5rem;
+    line-height: 2rem;
     font-weight: 800;
     scroll-margin: 5rem;
   }
   & :where(h2) {
-    font-size: 1.125rem;
+    font-size: 1.25rem;
     line-height: 1.75rem;
     font-weight: 700;
-    letter-spacing: -0.025em;
     border-bottom-width: 1px;
     padding-bottom: 0.5rem;
     scroll-margin: 5rem;
@@ -154,15 +166,18 @@
     font-size: 1.125rem;
     line-height: 1.75rem;
     font-weight: 600;
-    letter-spacing: -0.025em;
     scroll-margin: 5rem;
   }
   & :where(h4) {
     font-size: 1rem;
     line-height: 1.5rem;
     font-weight: 600;
-    letter-spacing: -0.025em;
     scroll-margin: 5rem;
+  }
+  & :where(hr) {
+    border-top-style: dashed;
+    margin-top: 2rem;
+    margin-bottom: 2rem;
   }
   & :where(blockquote) {
     border-left-width: 2px;
@@ -175,8 +190,18 @@
     text-underline-offset: 4px;
   }
   & :where(a):hover {
-    text-decoration-style: dotted;
-    text-decoration-thickness: 1px;
+    color: hsl(var(--accent-blue));
+    text-decoration-color: hsl(var(--accent-blue));
+  }
+  & :where(code) {
+    border: 1px solid hsl(var(--border));
+    background-color: hsl(var(--muted));
+    padding: 0.1rem 0.3rem;
+    font-weight: 600;
+  }
+  & :where(code)::before,
+  & :where(code)::after {
+    content: '';
   }
   & :where(ul) {
     list-style-type: disc;
@@ -199,16 +224,16 @@
     @apply border-border;
   }
   h1 {
-    @apply scroll-m-20 text-xl font-extrabold;
+    @apply scroll-m-20 text-2xl font-extrabold;
   }
   h2 {
-    @apply scroll-m-20 border-b pb-2 text-lg font-bold tracking-tight transition-colors first:mt-0;
+    @apply scroll-m-20 border-b pb-2 text-xl font-bold transition-colors first:mt-0;
   }
   h3 {
-    @apply scroll-m-20 text-lg font-semibold tracking-tight;
+    @apply scroll-m-20 text-lg font-semibold;
   }
   h4 {
-    @apply scroll-m-20 text-base font-semibold tracking-tight;
+    @apply scroll-m-20 text-base font-semibold;
   }
   p {
     @apply leading-7 not-first:mt-6;
@@ -220,9 +245,9 @@
     @apply my-6 ml-6 list-disc [&>li]:mt-2;
   }
   code {
-    @apply bg-muted relative rounded-none px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold;
+    @apply bg-muted border-border relative rounded-none border px-[0.3rem] py-[0.2rem] text-sm font-semibold;
   }
   a {
-    @apply underline underline-offset-4 hover:decoration-dotted hover:decoration-1;
+    @apply hover:text-accent-blue underline underline-offset-4;
   }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -27,6 +27,8 @@
   --color-accent: hsl(var(--accent));
   --color-accent-foreground: hsl(var(--accent-foreground));
 
+  --color-accent-blue: hsl(var(--accent-blue));
+
   --color-popover: hsl(var(--popover));
   --color-popover-foreground: hsl(var(--popover-foreground));
 
@@ -34,75 +36,90 @@
   --color-card-foreground: hsl(var(--card-foreground));
 
   --radius-lg: var(--radius);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: var(--radius);
+  --radius-sm: var(--radius);
 
-  --font-sans: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --shadow-card: 6px 6px 0 0 hsl(var(--shadow));
+  --shadow-card-sm: 4px 4px 0 0 hsl(var(--shadow));
+
+  --font-mono:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  --font-sans:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
 }
 
 :root {
   color-scheme: light;
-  --background: 0 0% 100%;
-  --foreground: 0 0% 22%;
+  --background: 42 20% 95%;
+  --foreground: 0 0% 14%;
 
   --card: 0 0% 100%;
-  --card-foreground: 240 10% 3.9%;
+  --card-foreground: 0 0% 14%;
 
   --popover: 0 0% 100%;
-  --popover-foreground: 240 10% 3.9%;
+  --popover-foreground: 0 0% 14%;
 
-  --primary: 240 5.9% 10%;
+  --primary: 0 0% 14%;
   --primary-foreground: 0 0% 98%;
 
-  --secondary: 240 4.8% 95.9%;
-  --secondary-foreground: 240 5.9% 10%;
+  --secondary: 42 20% 92%;
+  --secondary-foreground: 0 0% 14%;
 
-  --muted: 240 4.8% 95.9%;
-  --muted-foreground: 240 3.8% 46.1%;
+  --muted: 42 20% 92%;
+  --muted-foreground: 0 0% 42%;
 
-  --accent: 240 4.8% 95.9%;
-  --accent-foreground: 240 5.9% 10%;
+  --accent: 42 20% 92%;
+  --accent-foreground: 0 0% 14%;
 
-  --destructive: 0 84.2% 60.2%;
+  --accent-blue: 221 73% 50%;
+
+  --destructive: 0 74% 50%;
   --destructive-foreground: 0 0% 98%;
 
-  --border: 240 5.9% 90%;
-  --input: 240 5.9% 90%;
-  --ring: 240 10% 3.9%;
+  --border: 0 0% 78%;
+  --input: 0 0% 78%;
+  --ring: 221 73% 50%;
 
-  --radius: 0.5rem;
+  --shadow: 0 0% 75%;
+
+  --radius: 0;
 }
 
 .dark {
   color-scheme: dark;
-  --background: 0 0% 10%;
-  --foreground: 0 0% 89%;
+  --background: 0 0% 3%;
+  --foreground: 0 0% 92%;
 
-  --card: 240 10% 3.9%;
-  --card-foreground: 0 0% 98%;
+  --card: 0 0% 7%;
+  --card-foreground: 0 0% 92%;
 
-  --popover: 240 10% 3.9%;
-  --popover-foreground: 0 0% 98%;
+  --popover: 0 0% 7%;
+  --popover-foreground: 0 0% 92%;
 
-  --primary: 0 0% 98%;
-  --primary-foreground: 240 5.9% 10%;
+  --primary: 0 0% 92%;
+  --primary-foreground: 0 0% 7%;
 
-  --secondary: 240 3.7% 15.9%;
-  --secondary-foreground: 0 0% 98%;
+  --secondary: 0 0% 12%;
+  --secondary-foreground: 0 0% 92%;
 
-  --muted: 240 3.7% 15.9%;
+  --muted: 0 0% 12%;
   --muted-foreground: 0 0% 62%;
 
-  --accent: 240 3.7% 15.9%;
-  --accent-foreground: 0 0% 98%;
+  --accent: 0 0% 12%;
+  --accent-foreground: 0 0% 92%;
 
-  --destructive: 0 62.8% 30.6%;
+  --accent-blue: 215 85% 62%;
+
+  --destructive: 0 62% 45%;
   --destructive-foreground: 0 0% 98%;
 
-  --border: 240 3.7% 15.9%;
-  --input: 240 3.7% 15.9%;
-  --ring: 240 4.9% 83.9%;
+  --border: 0 0% 22%;
+  --input: 0 0% 22%;
+  --ring: 215 85% 62%;
+
+  --shadow: 0 0% 20%;
 }
 
 @utility prose-custom {
@@ -203,7 +220,7 @@
     @apply my-6 ml-6 list-disc [&>li]:mt-2;
   }
   code {
-    @apply bg-muted relative rounded-sm px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold;
+    @apply bg-muted relative rounded-none px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold;
   }
   a {
     @apply underline underline-offset-4 hover:decoration-dotted hover:decoration-1;


### PR DESCRIPTION
Replaces the generic shadcn palette and rounded corners with paper/ink tones, hairline borders, and hard offset drop shadows across the site.