### PR TITLE
feat(style): Finish restyle across blog, feed, photos, footer, OG

### DIFF
--- a/src/components/AlbumHeader.astro
+++ b/src/components/AlbumHeader.astro
@@ -15,12 +15,10 @@ const { title, year } = Astro.props;
   class="fixed top-0 left-0 flex w-full justify-between p-5 transition-opacity duration-300"
 >
   <div class="flex items-center gap-3">
-    <div class="text-2xl font-bold lowercase">
+    <div class="text-xl font-bold tracking-wider uppercase">
       {title}
     </div>
-    <div>
-      <Badge variant="secondary">{year}</Badge>
-    </div>
+    <Badge variant="bracket">{year}</Badge>
   </div>
   <ThemeToggle />
 </header>

--- a/src/components/FeaturedImage.astro
+++ b/src/components/FeaturedImage.astro
@@ -15,7 +15,9 @@ const name = image.name ?? 'Untitled';
 ---
 
 <div class:list={[className, 'flex flex-col']}>
-  <RemoteImage src={image.src} alt={name} loading="eager" fetchpriority="high" />
+  <div class="border-border border">
+    <RemoteImage src={image.src} alt={name} loading="eager" fetchpriority="high" />
+  </div>
   <div class="mt-2 flex flex-col justify-end">
     <div class="text-right text-base font-semibold">{name}</div>
   </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,7 @@
 ---
 const now = new Date();
 const year = now.getFullYear();
-const buildDate = now.toISOString().slice(0, 16).replace('T', ' ');
+const buildTimestampUtc = now.toISOString();
 ---
 
 <footer class="text-muted-foreground mt-20 mb-6 text-xs tracking-wider uppercase">
@@ -16,6 +16,6 @@ const buildDate = now.toISOString().slice(0, 16).replace('T', ' ');
     </div>
   </div>
   <div class="mt-1">
-    last built <time datetime={now.toISOString()}>{buildDate}</time> utc
+    last built <time datetime={buildTimestampUtc}>{buildTimestampUtc}</time>
   </div>
 </footer>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,21 @@
 ---
-const today = new Date();
+const now = new Date();
+const year = now.getFullYear();
+const buildDate = now.toISOString().slice(0, 16).replace('T', ' ');
 ---
 
-<footer class="py-6 text-center">
-  &copy; {today.getFullYear()} Sal Olivares. All rights reserved.
+<footer class="text-muted-foreground mt-20 mb-6 text-xs tracking-wider uppercase">
+  <div class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+    <div>&copy; {year} Sal Olivares &middot; Made in California</div>
+    <div class="flex gap-3">
+      <a href="/rss.xml" class="hover:text-accent-blue no-underline">[rss]</a>
+      <a
+        href="https://github.com/salolivares/salolivares.com"
+        class="hover:text-accent-blue no-underline">[github]</a
+      >
+    </div>
+  </div>
+  <div class="mt-1">
+    astro &nbsp;&middot;&nbsp; last built <time datetime={now.toISOString()}>{buildDate}</time> utc
+  </div>
 </footer>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -16,6 +16,6 @@ const buildDate = now.toISOString().slice(0, 16).replace('T', ' ');
     </div>
   </div>
   <div class="mt-1">
-    astro &nbsp;&middot;&nbsp; last built <time datetime={now.toISOString()}>{buildDate}</time> utc
+    last built <time datetime={now.toISOString()}>{buildDate}</time> utc
   </div>
 </footer>

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -18,7 +18,7 @@ const { prevUrl, nextUrl, currentPage, lastPage } = Astro.props;
       <div>
         {prevUrl && (
           <a href={prevUrl} class="hover:text-accent-blue no-underline" data-astro-prefetch>
-            [&larr; newer]
+            [newer]
           </a>
         )}
       </div>
@@ -28,7 +28,7 @@ const { prevUrl, nextUrl, currentPage, lastPage } = Astro.props;
       <div>
         {nextUrl && (
           <a href={nextUrl} class="hover:text-accent-blue no-underline" data-astro-prefetch>
-            [older &rarr;]
+            [older]
           </a>
         )}
       </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import BaseHead from '../components/BaseHead.astro';
+import Footer from '../components/Footer.astro';
 import Header from '../components/Header.astro';
 import type { MarkdownLayoutProps } from 'astro';
 
@@ -75,5 +76,6 @@ const { title, description, image, articleDate, articleUpdatedDate } = Astro.pro
     <main class:list={[{ 'prose-custom prose dark:prose-invert prose-hr:my-5': isMarkdown }]}>
       <slot />
     </main>
+    <Footer />
   </body>
 </html>

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -1,6 +1,5 @@
 ---
 import type { CollectionEntry } from 'astro:content';
-import FormattedDate from '../components/FormattedDate.astro';
 import BaseLayout from './BaseLayout.astro';
 import { Image } from 'astro:assets';
 
@@ -9,21 +8,32 @@ type Props = CollectionEntry<'blog'>;
 const { data, id } = Astro.props;
 const { title, subtitle, description, heroImage, heroImageAlt = null, pubDate, updatedDate, comments = true } = data;
 const ogImage = `/og-image/${id}.png`;
+
+const isoDate = (d: Date) => d.toISOString().slice(0, 10);
 ---
 
 <BaseLayout title={title} description={description} image={ogImage} articleDate={pubDate.toISOString()} articleUpdatedDate={updatedDate?.toISOString()}>
   <article class="prose prose-custom dark:prose-invert">
-    {heroImage && <Image width={720} height={360} src={heroImage} alt={heroImageAlt} />}
+    {heroImage && (
+      <Image
+        class="border-border not-prose mb-6 border"
+        width={720}
+        height={360}
+        src={heroImage}
+        alt={heroImageAlt}
+      />
+    )}
     <h1 class="mb-1">{title}</h1>
     {subtitle && <div class="text-muted-foreground mt-1 mb-3 italic">{subtitle}</div>}
-    <FormattedDate date={pubDate} />
-    {
-      updatedDate && (
-        <div class="italic">
-          Last updated on <FormattedDate date={updatedDate} />
-        </div>
-      )
-    }
+    <div class="text-muted-foreground text-sm tracking-wider uppercase">
+      Published <time datetime={pubDate.toISOString()} class="tabular-nums">{isoDate(pubDate)}</time>
+      {updatedDate && (
+        <>
+          &nbsp;·&nbsp;Updated
+          <time datetime={updatedDate.toISOString()} class="tabular-nums">{isoDate(updatedDate)}</time>
+        </>
+      )}
+    </div>
     <hr class="not-prose my-5 border-(--tw-prose-hr)" />
     <slot />
   </article>

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -9,6 +9,7 @@ const { data, id } = Astro.props;
 const { title, subtitle, description, heroImage, heroImageAlt = null, pubDate, updatedDate, comments = true } = data;
 const ogImage = `/og-image/${id}.png`;
 
+// Keep metadata dates fixed-width for scanability and consistency with list pages.
 const isoDate = (d: Date) => d.toISOString().slice(0, 10);
 ---
 
@@ -85,7 +86,7 @@ const isoDate = (d: Date) => d.toISOString().slice(0, 10);
       data-astro-prefetch="viewport"
       class="hover:text-accent-blue no-underline"
     >
-      [&larr; back to posts]
+      [back to posts]
     </a>
   </div>
 </BaseLayout>

--- a/src/pages/bestof/[id].astro
+++ b/src/pages/bestof/[id].astro
@@ -45,7 +45,7 @@ const { Content } = await render(post);
         data-astro-prefetch="viewport"
         class="hover:text-accent-blue no-underline"
       >
-        [&larr; back to feed]
+        [back to feed]
       </a>
     </div>
   </article>

--- a/src/pages/bestof/[id].astro
+++ b/src/pages/bestof/[id].astro
@@ -4,7 +4,6 @@ import { getCollection, render } from 'astro:content';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import FormattedDate from '@/components/FormattedDate.astro';
 import Badge from '@/components/Badge.astro';
-import { CornerDownLeft } from '@lucide/astro';
 
 export const getStaticPaths = (async () => {
   const posts = await getCollection('bestof', ({ data }) => {
@@ -24,30 +23,30 @@ const { Content } = await render(post);
 
 <BaseLayout title={post.data.title}>
   <article class="mt-6">
-    <div class="mb-4 flex items-center gap-2 text-sm text-muted-foreground">
+    <div class="text-muted-foreground mb-4 flex items-center gap-2 text-sm">
       <FormattedDate date={post.data.pubDate} />
       <span>&middot;</span>
-      <Badge variant="outline" class="px-1.5 py-0 text-[10px]">bestof</Badge>
+      <Badge variant="bracket">bestof</Badge>
+      {post.data.source && (
+        <>
+          <span>&middot;</span>
+          <a href={post.data.source} class="hover:text-accent-blue text-accent-blue no-underline">
+            [source]
+          </a>
+        </>
+      )}
     </div>
-    {post.data.source && (
-      <a href={post.data.source} class="text-sm text-muted-foreground hover:text-foreground">
-        source
-      </a>
-    )}
     <div class="prose prose-custom dark:prose-invert max-w-none">
       <Content />
     </div>
-    <div class="flex flex-col items-center">
-      <div class="my-24">
-        <a
-          href="/feed"
-          data-astro-prefetch="viewport"
-          aria-label="Back to feed"
-          class="rounded-full p-6 transition-colors duration-200 hover:opacity-50 dark:hover:opacity-75"
-        >
-          <CornerDownLeft />
-        </a>
-      </div>
+    <div class="mt-24 flex flex-col items-center">
+      <a
+        href="/feed"
+        data-astro-prefetch="viewport"
+        class="hover:text-accent-blue no-underline"
+      >
+        [&larr; back to feed]
+      </a>
     </div>
   </article>
 </BaseLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -39,7 +39,7 @@ const posts = (
               aria-hidden="true"
               tabindex="-1"
             >
-              [read &rarr;]
+              [read]
             </a>
           </li>
         ))

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -4,7 +4,6 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 
 const posts = (
   await getCollection('blog', ({ data }) => {
-    // Only return published posts in production
     return import.meta.env.PROD ? data.published === true : true;
   })
 ).sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
@@ -13,19 +12,34 @@ const posts = (
 <BaseLayout title="Blog">
   <h1 class="sr-only">Blog</h1>
   <section class="mt-6">
-    <ul class="m-0 list-none">
+    <ul class="m-0 list-none space-y-3">
       {
         posts.map((post) => (
-          <li class="mt-5 flex flex-col sm:mt-2 sm:flex-row">
-            <time datetime={post.data.pubDate.toISOString()} class="sm:basis-32">
+          <li class="grid grid-cols-[auto_1fr_auto] items-baseline gap-x-4">
+            <time
+              datetime={post.data.pubDate.toISOString()}
+              class="text-muted-foreground tabular-nums"
+            >
               {post.data.pubDate.toLocaleDateString('fr-ca', {
                 year: 'numeric',
-                month: 'numeric',
-                day: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
               })}
             </time>
-            <a href={`/blog/${post.id}`} class="font-semibold" data-astro-prefetch>
+            <a
+              href={`/blog/${post.id}`}
+              class="hover:text-accent-blue font-semibold no-underline"
+              data-astro-prefetch
+            >
               {post.data.title}
+            </a>
+            <a
+              href={`/blog/${post.id}`}
+              class="text-accent-blue hidden no-underline sm:inline"
+              aria-hidden="true"
+              tabindex="-1"
+            >
+              [read &rarr;]
             </a>
           </li>
         ))

--- a/src/pages/feed/[...page].astro
+++ b/src/pages/feed/[...page].astro
@@ -25,13 +25,19 @@ const renderedItems = await Promise.all(
   <h1 class="sr-only">Feed</h1>
 
   <nav class="mt-6 flex gap-3 text-sm" aria-label="Feed filters">
-    <span class="font-semibold">All</span>
+    <span class="text-accent-blue">[all]</span>
     {FEED_TYPES.map((type) => (
-      <a href={`/feed/${type}`} data-astro-prefetch>{type}</a>
+      <a
+        href={`/feed/${type}`}
+        class="hover:text-accent-blue no-underline"
+        data-astro-prefetch
+      >
+        [{type}]
+      </a>
     ))}
   </nav>
 
-  <section class="mt-4">
+  <section class="mt-6">
     {renderedItems.map(({ Content, ...item }) => (
       <FeedItem pubDate={item.pubDate} type={item.type} permalink={getPermalink(item)}>
         <Content />

--- a/src/pages/feed/[type]/[...page].astro
+++ b/src/pages/feed/[type]/[...page].astro
@@ -36,17 +36,23 @@ const renderedItems = await Promise.all(
   <h1 class="sr-only">Feed - {type}</h1>
 
   <nav class="mt-6 flex gap-3 text-sm" aria-label="Feed filters">
-    <a href="/feed" data-astro-prefetch>All</a>
+    <a href="/feed" class="hover:text-accent-blue no-underline" data-astro-prefetch>[all]</a>
     {FEED_TYPES.map((t) =>
       t === type ? (
-        <span class="font-semibold">{t}</span>
+        <span class="text-accent-blue">[{t}]</span>
       ) : (
-        <a href={`/feed/${t}`} data-astro-prefetch>{t}</a>
+        <a
+          href={`/feed/${t}`}
+          class="hover:text-accent-blue no-underline"
+          data-astro-prefetch
+        >
+          [{t}]
+        </a>
       )
     )}
   </nav>
 
-  <section class="mt-4">
+  <section class="mt-6">
     {renderedItems.map(({ Content, ...item }) => (
       <FeedItem pubDate={item.pubDate} type={item.type} permalink={getPermalink(item)}>
         <Content />

--- a/src/pages/now/[id].astro
+++ b/src/pages/now/[id].astro
@@ -4,7 +4,6 @@ import { getCollection, render } from 'astro:content';
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import FormattedDate from '@/components/FormattedDate.astro';
 import Badge from '@/components/Badge.astro';
-import { CornerDownLeft } from '@lucide/astro';
 
 export const getStaticPaths = (async () => {
   const posts = await getCollection('now', ({ data }) => {
@@ -24,25 +23,22 @@ const { Content } = await render(post);
 
 <BaseLayout title={post.data.title || 'now'}>
   <article class="mt-6">
-    <div class="mb-4 flex items-center gap-2 text-sm text-muted-foreground">
+    <div class="text-muted-foreground mb-4 flex items-center gap-2 text-sm">
       <FormattedDate date={post.data.pubDate} />
       <span>&middot;</span>
-      <Badge variant="outline" class="px-1.5 py-0 text-[10px]">now</Badge>
+      <Badge variant="bracket">now</Badge>
     </div>
     <div class="prose prose-custom dark:prose-invert max-w-none">
       <Content />
     </div>
-    <div class="flex flex-col items-center">
-      <div class="my-24">
-        <a
-          href="/feed"
-          data-astro-prefetch="viewport"
-          aria-label="Back to feed"
-          class="rounded-full p-6 transition-colors duration-200 hover:opacity-50 dark:hover:opacity-75"
-        >
-          <CornerDownLeft />
-        </a>
-      </div>
+    <div class="mt-24 flex flex-col items-center">
+      <a
+        href="/feed"
+        data-astro-prefetch="viewport"
+        class="hover:text-accent-blue no-underline"
+      >
+        [&larr; back to feed]
+      </a>
     </div>
   </article>
 </BaseLayout>

--- a/src/pages/now/[id].astro
+++ b/src/pages/now/[id].astro
@@ -37,7 +37,7 @@ const { Content } = await render(post);
         data-astro-prefetch="viewport"
         class="hover:text-accent-blue no-underline"
       >
-        [&larr; back to feed]
+        [back to feed]
       </a>
     </div>
   </article>

--- a/src/pages/og-image/[slug].png.ts
+++ b/src/pages/og-image/[slug].png.ts
@@ -9,6 +9,12 @@ import { html } from 'satori-html';
 const INTER_REGULAR = './node_modules/@fontsource/inter/files/inter-latin-400-normal.woff';
 const INTER_BOLD = './node_modules/@fontsource/inter/files/inter-latin-700-normal.woff';
 
+const PAPER = '#f3efe7';
+const INK = '#242322';
+const MUTED = '#6a6a6a';
+const BORDER = '#c7c7c7';
+const ACCENT = '#2a5cd8';
+
 interface Props {
   title: string;
   pubDate: Date;
@@ -16,9 +22,7 @@ interface Props {
 
 export async function GET(context: APIContext) {
   const { title, pubDate } = context.props as Props;
-  const date = pubDate.toLocaleDateString('en-US', {
-    dateStyle: 'full',
-  });
+  const date = pubDate.toISOString().slice(0, 10);
 
   const [avatarBuffer, interRegular, interBold] = await Promise.all([
     readFile('./public/images/avatar.png'),
@@ -27,18 +31,30 @@ export async function GET(context: APIContext) {
   ]);
   const avatar = `data:image/png;base64,${avatarBuffer.toString('base64')}`;
 
-  const markup = html`<div tw="flex flex-col w-full h-full items-center justify-center bg-white">
-    <div tw="flex flex-col w-full h-4/5 p-10 justify-center">
-      <div tw="text-3xl font-normal mb-10">${date}</div>
-      <div tw="text-6xl font-bold leading-snug tracking-tight">${title}</div>
-    </div>
-    <div tw="flex w-full h-1/5 px-10 pb-10 justify-between">
-      <div tw="text-3xl font-normal items-center" style={{ textDecoration: 'underline' }}>salolivares.com</div>
-      <div tw="flex items-center">
-        <img src="${avatar}" tw="w-20 mr-5" />
-        <div tw="flex flex-col">
-          <div tw="font-bold text-3xl">sal olivares</div>
-          <div tw="text-2xl">@0x102c</div>
+  const markup = html`<div
+    tw="flex flex-col w-full h-full items-stretch justify-center p-10"
+    style=${{ backgroundColor: PAPER, color: INK }}
+  >
+    <div
+      tw="flex flex-col w-full h-full p-16 justify-between border"
+      style=${{ borderColor: BORDER, backgroundColor: '#ffffff' }}
+    >
+      <div tw="flex flex-col">
+        <div tw="text-2xl mb-8" style=${{ color: MUTED, letterSpacing: '0.12em' }}>
+          POST · ${date}
+        </div>
+        <div tw="text-6xl font-bold leading-snug">${title}</div>
+      </div>
+      <div tw="flex w-full justify-between items-end">
+        <div tw="text-2xl" style=${{ color: ACCENT, textDecoration: 'underline' }}>
+          salolivares.com
+        </div>
+        <div tw="flex items-center">
+          <img src="${avatar}" tw="w-16 mr-4" />
+          <div tw="flex flex-col">
+            <div tw="font-bold text-2xl">sal olivares</div>
+            <div tw="text-xl" style=${{ color: MUTED }}>@0x102c</div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/photos/[album].astro
+++ b/src/pages/photos/[album].astro
@@ -51,7 +51,7 @@ const { images } = album.data;
         data-astro-prefetch="viewport"
         class="hover:text-accent-blue no-underline"
       >
-        [&larr; back to albums]
+        [back to albums]
       </a>
     </div>
   </div>

--- a/src/pages/photos/index.astro
+++ b/src/pages/photos/index.astro
@@ -5,7 +5,6 @@ import { getCollection } from 'astro:content';
 
 const albums = (
   await getCollection('photos', ({ data }) => {
-    // Only return published posts in production
     return import.meta.env.PROD ? data.published === true : true;
   })
 ).sort((a, b) => b.data.year - a.data.year);
@@ -28,14 +27,26 @@ const featuredImage = allImages[Math.floor(Math.random() * allImages.length)];
 <BaseLayout title="Photos">
   <h1 class="sr-only">Photos</h1>
   <FeaturedImage image={featuredImage} class="mt-6" />
-  <section class="mb-20">
-    <ul class="m-0 list-none">
+  <section class="mt-10 mb-20">
+    <ul class="m-0 list-none space-y-3">
       {
         albums.map((photo) => (
-          <li class="mt-5 flex flex-col sm:mt-2 sm:flex-row">
-            <div class="sm:basis-20">{photo.data.year}</div>
-            <a href={`/photos/${photo.id}`} class="font-semibold" data-astro-prefetch>
+          <li class="grid grid-cols-[auto_1fr_auto] items-baseline gap-x-4">
+            <div class="text-muted-foreground tabular-nums">{photo.data.year}</div>
+            <a
+              href={`/photos/${photo.id}`}
+              class="hover:text-accent-blue font-semibold no-underline"
+              data-astro-prefetch
+            >
               {photo.data.title}
+            </a>
+            <a
+              href={`/photos/${photo.id}`}
+              class="text-accent-blue hidden no-underline sm:inline"
+              aria-hidden="true"
+              tabindex="-1"
+            >
+              [view &rarr;]
             </a>
           </li>
         ))

--- a/src/pages/photos/index.astro
+++ b/src/pages/photos/index.astro
@@ -46,7 +46,7 @@ const featuredImage = allImages[Math.floor(Math.random() * allImages.length)];
               aria-hidden="true"
               tabindex="-1"
             >
-              [view &rarr;]
+              [view]
             </a>
           </li>
         ))


### PR DESCRIPTION
## Context

Second and final tranche of the monospace/datasheet restyle, landing
the remaining plan items after the foundational changes in #73. Brings
every remaining page and the OG image into the new paper/ink,
hairline-border, bracket-UI language.

## Solution

One commit covering PRs 4–7 of the restyle plan: tabular
Date/Year | Title | bracket-link rows on \`/blog\` and \`/photos\`; blog
post gets a 1px hero border and allcaps PUBLISHED/UPDATED metadata row;
bestof/now single pages swap rounded-icon back buttons for
\`[← back to feed]\` and use the \`bracket\` Badge variant; feed filter
nav becomes \`[all] [bestof] [now]\` bracket-tabs with accent-blue
active state; AlbumHeader uses allcaps + bracket year badge;
FeaturedImage frames the photo with a hairline border; Footer is
allcaps mono with build timestamp + bracket social links, mounted
globally via BaseLayout; OG Satori template repalleted to
cream/ink/accent-blue. Targets \`next\` to stack cleanly on #73 before
cutover to \`master\`.

## Testing plan

- \`pnpm build\` produces all 45 pages with no errors
- Visually verified in Chrome DevTools MCP, light + dark, across
  \`/\`, \`/blog\`, a blog post, \`/photos\`, \`/feed\`, \`/feed/bestof\`
- Screenshots saved under \`.context/pr4-*.png\`

## Security

N/A — visual/structural CSS, component, and Astro page changes only.
No auth, input handling, or new dependencies.