### PR TITLE
feat(photos): Add album-specific OG image and social meta

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -61,6 +61,7 @@ const photos = defineCollection({
   loader: glob({ pattern: '**/*.json', base: './src/content/photos' }),
   schema: z.object({
     title: z.string(),
+    description: z.string(),
     location: z.string().optional(),
     year: z.number(),
     published: z.boolean().default(false),

--- a/src/content/photos/2017-japan.json
+++ b/src/content/photos/2017-japan.json
@@ -1,5 +1,6 @@
 {
   "title": "Tokyo",
+  "description": "A first trip to Tokyo.",
   "location": "Japan",
   "year": 2017,
   "published": true,

--- a/src/content/photos/2017-japan.json
+++ b/src/content/photos/2017-japan.json
@@ -1,6 +1,6 @@
 {
   "title": "Tokyo",
-  "description": "A first trip to Tokyo.",
+  "description": "My first trip to Japan.",
   "location": "Japan",
   "year": 2017,
   "published": true,

--- a/src/content/photos/2018-japan.json
+++ b/src/content/photos/2018-japan.json
@@ -1,5 +1,6 @@
 {
   "title": "Tokyo & Kyoto",
+  "description": "A return to Japan, this time across Tokyo and Kyoto.",
   "location": "Japan",
   "year": 2018,
   "published": true,

--- a/src/content/photos/2018-japan.json
+++ b/src/content/photos/2018-japan.json
@@ -1,6 +1,6 @@
 {
   "title": "Tokyo & Kyoto",
-  "description": "A return to Japan, this time across Tokyo and Kyoto.",
+  "description": "A return to Japan, this time with my brother.",
   "location": "Japan",
   "year": 2018,
   "published": true,

--- a/src/content/photos/2019-chicago.json
+++ b/src/content/photos/2019-chicago.json
@@ -1,6 +1,6 @@
 {
   "title": "Chicago",
-  "description": "A weekend wandering Chicago.",
+  "description": "A week wandering Chicago during the artic freeze.",
   "location": "USA",
   "year": 2019,
   "published": true,

--- a/src/content/photos/2019-chicago.json
+++ b/src/content/photos/2019-chicago.json
@@ -1,5 +1,6 @@
 {
   "title": "Chicago",
+  "description": "A weekend wandering Chicago.",
   "location": "USA",
   "year": 2019,
   "published": true,

--- a/src/content/photos/2021-arizona.json
+++ b/src/content/photos/2021-arizona.json
@@ -1,5 +1,6 @@
 {
   "title": "Arizona",
+  "description": "Desert light and saguaros across Arizona.",
   "location": "USA",
   "year": 2021,
   "published": true,

--- a/src/content/photos/2021-arizona.json
+++ b/src/content/photos/2021-arizona.json
@@ -1,6 +1,6 @@
 {
   "title": "Arizona",
-  "description": "Desert light and saguaros across Arizona.",
+  "description": "Road tripping across arizona.",
   "location": "USA",
   "year": 2021,
   "published": true,

--- a/src/content/photos/2022-pnw.json
+++ b/src/content/photos/2022-pnw.json
@@ -1,6 +1,6 @@
 {
   "title": "Seattle & Portland",
-  "description": "Coffee, rain, and bookstores across the Pacific Northwest.",
+  "description": "A week in the PNW.",
   "location": "USA",
   "year": 2022,
   "published": true,

--- a/src/content/photos/2022-pnw.json
+++ b/src/content/photos/2022-pnw.json
@@ -1,5 +1,6 @@
 {
   "title": "Seattle & Portland",
+  "description": "Coffee, rain, and bookstores across the Pacific Northwest.",
   "location": "USA",
   "year": 2022,
   "published": true,

--- a/src/content/photos/2025-denmark.json
+++ b/src/content/photos/2025-denmark.json
@@ -1,5 +1,6 @@
 {
   "title": "Denmark",
+  "description": "A week across Copenhagen and Middelfart, shot on the Fujifilm X-T30 II.",
   "location": "Denmark",
   "year": 2025,
   "published": true,

--- a/src/content/photos/2025-denmark.json
+++ b/src/content/photos/2025-denmark.json
@@ -1,6 +1,6 @@
 {
   "title": "Denmark",
-  "description": "A week across Copenhagen and Middelfart, shot on the Fujifilm X-T30 II.",
+  "description": "A month in Copenhagen and several Danish cities. Shot on the Fujifilm X-T30 II.",
   "location": "Denmark",
   "year": 2025,
   "published": true,

--- a/src/content/photos/2025-germany.json
+++ b/src/content/photos/2025-germany.json
@@ -1,5 +1,6 @@
 {
   "title": "Germany",
+  "description": "A trip through Germany.",
   "location": "Germany",
   "year": 2025,
   "published": true,

--- a/src/content/photos/2025-germany.json
+++ b/src/content/photos/2025-germany.json
@@ -1,6 +1,6 @@
 {
   "title": "Germany",
-  "description": "A trip through Germany.",
+  "description": "A weekend trip to Berlin.",
   "location": "Germany",
   "year": 2025,
   "published": true,

--- a/src/content/photos/2025-san-diego.json
+++ b/src/content/photos/2025-san-diego.json
@@ -1,5 +1,6 @@
 {
     "title": "San Diego",
+    "description": "Hometown sun, a day at a time.",
     "location": "San Diego",
     "year": 2025,
     "published": true,

--- a/src/content/photos/2025-san-diego.json
+++ b/src/content/photos/2025-san-diego.json
@@ -1,6 +1,6 @@
 {
     "title": "San Diego",
-    "description": "Hometown sun, a day at a time.",
+    "description": "A couple pics from my 2 years in SD.",
     "location": "San Diego",
     "year": 2025,
     "published": true,

--- a/src/content/photos/chikis.json
+++ b/src/content/photos/chikis.json
@@ -1,6 +1,6 @@
 {
   "title": "Chikis",
-  "description": "A collection of photos of Chikis.",
+  "description": "A collection of photos of my late doggy Chikis.",
   "year": 2023,
   "published": true,
   "images": [

--- a/src/content/photos/chikis.json
+++ b/src/content/photos/chikis.json
@@ -1,5 +1,6 @@
 {
   "title": "Chikis",
+  "description": "A collection of photos of Chikis.",
   "year": 2023,
   "published": true,
   "images": [

--- a/src/layouts/AlbumLayout.astro
+++ b/src/layouts/AlbumLayout.astro
@@ -59,7 +59,11 @@ const { album } = Astro.props;
 
       window.localStorage.setItem('theme', theme);
     </script>
-    <BaseHead title={album.data.title} />
+    <BaseHead
+      title={`${album.data.title} ${album.data.year}`}
+      description={album.data.description}
+      image={`/og-image/photos/${album.id}.png`}
+    />
   </head>
   <body>
     <AlbumHeader title={album.data.title} year={album.data.year} />

--- a/src/pages/og-image/[slug].png.ts
+++ b/src/pages/og-image/[slug].png.ts
@@ -33,7 +33,7 @@ export async function GET(context: APIContext) {
       <div tw="text-6xl font-bold leading-snug tracking-tight">${title}</div>
     </div>
     <div tw="flex w-full h-1/5 px-10 pb-10 justify-between">
-      <div tw="text-3xl font-normal items-center" style={{ textDecoration: 'underline' }}>salolivares.com</div>
+      <div tw="text-3xl font-normal items-center" style={{ textDecoration: 'underline', textUnderlineOffset: '12px' }}>salolivares.com</div>
       <div tw="flex items-center">
         <img src="${avatar}" tw="w-20 mr-5" />
         <div tw="flex flex-col">

--- a/src/pages/og-image/photos/[album].png.ts
+++ b/src/pages/og-image/photos/[album].png.ts
@@ -1,0 +1,128 @@
+import { config } from '@/site.config';
+import { Resvg } from '@resvg/resvg-js';
+import { readFile } from 'node:fs/promises';
+import type { APIContext, GetStaticPathsResult } from 'astro';
+import { getCollection } from 'astro:content';
+import satori from 'satori';
+
+const INTER_REGULAR = './node_modules/@fontsource/inter/files/inter-latin-400-normal.woff';
+const INTER_BOLD = './node_modules/@fontsource/inter/files/inter-latin-700-normal.woff';
+
+interface Props {
+  title: string;
+  year: number;
+}
+
+export async function GET(context: APIContext) {
+  const { title, year } = context.props as Props;
+
+  const [avatarBuffer, interRegular, interBold] = await Promise.all([
+    readFile('./public/images/avatar.png'),
+    readFile(INTER_REGULAR),
+    readFile(INTER_BOLD),
+  ]);
+  const avatar = `data:image/png;base64,${avatarBuffer.toString('base64')}`;
+
+  const markup = {
+    type: 'div',
+    props: {
+      tw: 'flex flex-col w-full h-full items-center justify-center bg-white',
+      children: [
+        {
+          type: 'div',
+          props: {
+            tw: 'flex flex-col w-full h-4/5 p-10 justify-center',
+            children: [
+              {
+                type: 'div',
+                props: { tw: 'text-3xl font-normal mb-10', children: String(year) },
+              },
+              {
+                type: 'div',
+                props: {
+                  tw: 'text-6xl font-bold leading-snug tracking-tight',
+                  children: title,
+                },
+              },
+            ],
+          },
+        },
+        {
+          type: 'div',
+          props: {
+            tw: 'flex w-full h-1/5 px-10 pb-10 justify-between',
+            children: [
+              {
+                type: 'div',
+                props: {
+                  tw: 'text-3xl font-normal items-center',
+                  style: { textDecoration: 'underline', textUnderlineOffset: '12px' },
+                  children: 'salolivares.com',
+                },
+              },
+              {
+                type: 'div',
+                props: {
+                  tw: 'flex items-center',
+                  children: [
+                    {
+                      type: 'img',
+                      props: { src: avatar, tw: 'w-20 mr-5' },
+                    },
+                    {
+                      type: 'div',
+                      props: {
+                        tw: 'flex flex-col',
+                        children: [
+                          {
+                            type: 'div',
+                            props: { tw: 'font-bold text-3xl', children: 'sal olivares' },
+                          },
+                          {
+                            type: 'div',
+                            props: { tw: 'text-2xl', children: '@0x102c' },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+
+  const svg = await satori(markup, {
+    width: config.ogImageWidth,
+    height: config.ogImageHeight,
+    fonts: [
+      {
+        name: 'Inter',
+        data: interRegular.buffer,
+        weight: 400,
+      },
+      {
+        name: 'Inter',
+        data: interBold.buffer,
+        weight: 700,
+      },
+    ],
+  });
+
+  const png = new Resvg(svg, { fitTo: { mode: 'width', value: config.ogImageWidth } })
+    .render()
+    .asPng();
+
+  return new Response(png);
+}
+
+export async function getStaticPaths(): Promise<GetStaticPathsResult> {
+  const albums = await getCollection('photos');
+  return albums.map((album) => ({
+    params: { album: album.id },
+    props: { title: album.data.title, year: album.data.year },
+  }));
+}


### PR DESCRIPTION
## Context

Photo album pages shared the site-wide `og:description` and a
generic social banner, so links to e.g. `/photos/2025-denmark` only
showed "Denmark" + the default site tagline when shared.

## Solution

Added a required `description` field to the photos collection and
updated `AlbumLayout` to pass `og:title` as `"{title} {year}"`,
`og:description` from the new field, and a dynamic OG image at
`/og-image/photos/{id}.png` (year above, title below, footer kept
as on the blog OG). Backfilled placeholder descriptions for the 9
existing albums. Also bumped `text-underline-offset` to `12px` on
both the blog and photo OG footer links for breathing room.

## Testing plan

- `pnpm build` passes (all 9 album OG PNGs generate at build time)
- Verified meta tags and the rendered OG PNG in the dev server for
  Denmark and Tokyo & Kyoto
- Edit the placeholder descriptions in `src/content/photos/*.json`
  to taste

## Security

N/A