### PR TITLE
fix(photos): Cap featured image height and center portraits

### DIFF
--- a/src/components/FeaturedImage.astro
+++ b/src/components/FeaturedImage.astro
@@ -14,7 +14,7 @@ const name = image.name ?? 'Untitled';
 ---
 
 <div class:list={[className, 'flex flex-col']}>
-  <div class="border-border border">
+  <div class="border-border flex justify-center border [&_img]:!max-h-[65vh]">
     <RemoteImage src={image.src} alt={name} loading="eager" fetchpriority="high" />
   </div>
   <div class="mt-2 flex flex-col justify-end">


### PR DESCRIPTION
## Context

Portrait photos in the `/photos` featured slot hit the 80vh inline
max-height before the width constraint, so on desktop they render
narrow and left-aligned, leaving a big empty column to the right and
pushing the album list below the fold.

## Solution

In `FeaturedImage.astro`, center the image and cap it at 65vh via a
scoped Tailwind override (`[&_img]:!max-h-[65vh]`). The `!` is needed
to beat the inline `max-height: 80vh` on `RemoteImage`, which still
applies on album pages. Landscape images are unchanged since they're
width-constrained at ~560px.