### PR TITLE
fix(photos): Override sizes on featured image to pick 1280w variant

### DIFF
--- a/src/components/FeaturedImage.astro
+++ b/src/components/FeaturedImage.astro
@@ -15,17 +15,13 @@ const name = image.name ?? 'Untitled';
 
 <div class:list={[className, 'flex flex-col']}>
   <div class="border-border flex justify-center border [&_img]:!max-h-[65vh]">
-    {/*
-      Featured image is capped at 65vh within the ~640px main column,
-      so the 1280w variant is enough at 2×DPR. Without this override
-      the browser picks 2880w (~1.5MB) per RemoteImage's default sizes.
-    */}
+    {/* Capped at 65vh in the ~640px main column, so 1280w suffices at 2×DPR. */}
     <RemoteImage
       src={image.src}
       alt={name}
       loading="eager"
       fetchpriority="high"
-      sizes="(max-width: 640px) 100vw, 640px"
+      maxWidth={640}
     />
   </div>
   <div class="mt-2 flex flex-col justify-end">

--- a/src/components/FeaturedImage.astro
+++ b/src/components/FeaturedImage.astro
@@ -15,7 +15,18 @@ const name = image.name ?? 'Untitled';
 
 <div class:list={[className, 'flex flex-col']}>
   <div class="border-border flex justify-center border [&_img]:!max-h-[65vh]">
-    <RemoteImage src={image.src} alt={name} loading="eager" fetchpriority="high" />
+    {/*
+      Featured image is capped at 65vh within the ~640px main column,
+      so the 1280w variant is enough at 2×DPR. Without this override
+      the browser picks 2880w (~1.5MB) per RemoteImage's default sizes.
+    */}
+    <RemoteImage
+      src={image.src}
+      alt={name}
+      loading="eager"
+      fetchpriority="high"
+      sizes="(max-width: 640px) 100vw, 640px"
+    />
   </div>
   <div class="mt-2 flex flex-col justify-end">
     <div class="text-right text-base font-semibold">{name}</div>

--- a/src/components/RemoteImage.astro
+++ b/src/components/RemoteImage.astro
@@ -7,7 +7,10 @@ interface Props {
   class?: string;
   loading?: 'lazy' | 'eager';
   fetchpriority?: 'high' | 'low' | 'auto';
-  sizes?: string;
+  /** Max CSS px the image will render at. Drives srcset selection:
+   * at 2×DPR the browser needs maxWidth × 2 physical px. With CDN
+   * variants of 1280w/2880w, keep maxWidth ≤ 640 to land on 1280w. */
+  maxWidth?: number;
   [index: string]: any;
 }
 
@@ -18,10 +21,11 @@ const {
   class: className,
   loading = 'lazy',
   fetchpriority,
-  sizes = '(max-width: 1280px) 100vw, 1280px',
+  maxWidth = 1280,
   ...rest
 } = Astro.props;
 const src = encodeURIComponent(propSrc);
+const sizes = `(max-width: ${maxWidth}px) 100vw, ${maxWidth}px`;
 ---
 
 <picture class={className} {...rest}>

--- a/src/components/RemoteImage.astro
+++ b/src/components/RemoteImage.astro
@@ -7,13 +7,21 @@ interface Props {
   class?: string;
   loading?: 'lazy' | 'eager';
   fetchpriority?: 'high' | 'low' | 'auto';
+  sizes?: string;
   [index: string]: any;
 }
 
 const host = 'https://photos.salolivares.com';
-const { src: propSrc, alt = '', class: className, loading = 'lazy', fetchpriority, ...rest } = Astro.props;
+const {
+  src: propSrc,
+  alt = '',
+  class: className,
+  loading = 'lazy',
+  fetchpriority,
+  sizes = '(max-width: 1280px) 100vw, 1280px',
+  ...rest
+} = Astro.props;
 const src = encodeURIComponent(propSrc);
-const sizes = '(max-width: 1280px) 100vw, 1280px';
 ---
 
 <picture class={className} {...rest}>


### PR DESCRIPTION
The featured image on /photos was downloading the 2880w CDN variant (~1.5MB) even though it renders at ~632px wide. RemoteImage's default `sizes` attribute claimed 1280px, so at 2x DPR the browser picked the larger variant. Overriding `sizes` on FeaturedImage keeps it on the 1280w file (~281KB). Album pages are unchanged since their wider column still warrants 2880w on retina.