### PR TITLE
fix(analytics): Render Plausible init as raw inline script

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -78,9 +78,10 @@ const socialImageURL = new URL(image, Astro.url);
     <>
       {/* Privacy-friendly analytics by Plausible */}
       <script async src="https://plausible.salolivares.com/js/pa-afhHhi8CXbKwUFEsklVn6.js" />
-      <script is:inline>
-        {`window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init();`}
-      </script>
+      <script
+        is:inline
+        set:html="window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init();"
+      />
     </>
   )
 }


### PR DESCRIPTION
Inside the conditional JSX expression, `` {`...`} `` was emitted as
literal text instead of being evaluated, because children of a
`<script>` inside an expression are parsed as JSX. Switch to
`set:html` so the script body is written directly to the tag.