### PR TITLE
fix(analytics): Move SpeedInsights last so Plausible stays in <head>

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -70,8 +70,6 @@ const socialImageURL = new URL(image, Astro.url);
 <meta property="twitter:description" content={description} />
 <meta property="twitter:image" content={socialImageURL} />
 
-<SpeedInsights />
-
 {
   import.meta.env.PROD && (
     <>
@@ -84,3 +82,6 @@ const socialImageURL = new URL(image, Astro.url);
     </>
   )
 }
+
+{/* Must be last: renders a <vercel-speed-insights> custom element that triggers implicit </head>, so anything after it ends up in <body>. */}
+<SpeedInsights />


### PR DESCRIPTION
## Solution

`SpeedInsights` renders a `<vercel-speed-insights>` custom element,
which the HTML parser treats as non-head-permitted content — it
implicitly closes `</head>` and reparents everything after it into
`<body>`. Render `SpeedInsights` last in `BaseHead` so the Plausible
script tags stay in `<head>` as intended.