### PR TITLE
feat(analytics): Switch from Plausible to Umami

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -73,12 +73,8 @@ const socialImageURL = new URL(image, Astro.url);
 {
   import.meta.env.PROD && (
     <>
-      {/* Privacy-friendly analytics by Plausible (proxied via /js/script.js + /api/event) */}
-      <script async src="/js/script.js" />
-      <script
-        is:inline
-        set:html={`window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init({endpoint:"/api/event"});`}
-      />
+      {/* Umami analytics (proxied via /script.js + /api/send) */}
+      <script is:inline defer src="/script.js" data-website-id="1428040f-11cf-4cde-af31-475f18942be7" />
     </>
   )
 }

--- a/vercel.json
+++ b/vercel.json
@@ -14,8 +14,8 @@
       "destination": "https://umami.salolivares.com/script.js"
     },
     {
-      "source": "/api/send",
-      "destination": "https://umami.salolivares.com/api/send"
+      "source": "/api/submit",
+      "destination": "https://umami.salolivares.com/api/submit"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -10,12 +10,12 @@
   ],
   "rewrites": [
     {
-      "source": "/js/script.js",
-      "destination": "https://plausible.salolivares.com/js/pa-afhHhi8CXbKwUFEsklVn6.js"
+      "source": "/script.js",
+      "destination": "https://umami.salolivares.com/script.js"
     },
     {
-      "source": "/api/event",
-      "destination": "https://plausible.salolivares.com/api/event"
+      "source": "/api/send",
+      "destination": "https://umami.salolivares.com/api/send"
     }
   ]
 }


### PR DESCRIPTION
## Solution

Replace the Plausible script + inline init block with Umami's single
script tag, and swap the Vercel rewrites. `/script.js` and
`/api/send` now proxy to the self-hosted Umami instance at
`umami.salolivares.com`, keeping the first-party pattern that bypasses
blockers.