### PR TITLE
perf(head): Scope photos preconnect to /photos and drop tw-animate-css

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "satori-html": "^0.3.2",
     "sharp": "^0.34.5",
     "tailwind-merge": "^3.5.0",
-    "tailwindcss": "^4.2.2",
-    "tw-animate-css": "^1.4.0"
+    "tailwindcss": "^4.2.2"
   },
   "packageManager": "pnpm@10.33.0",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
-      tw-animate-css:
-        specifier: ^1.4.0
-        version: 1.4.0
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -2243,9 +2240,6 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
-  tw-animate-css@1.4.0:
-    resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -4755,8 +4749,6 @@ snapshots:
 
   tslib@2.8.1:
     optional: true
-
-  tw-animate-css@1.4.0: {}
 
   type-check@0.4.0:
     dependencies:

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -32,7 +32,6 @@ const socialImageURL = new URL(image, Astro.url);
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-<link rel="preconnect" href="https://photos.salolivares.com" />
 <meta name="generator" content={Astro.generator} />
 <link rel="sitemap" href="/sitemap-index.xml" />
 
@@ -78,6 +77,8 @@ const socialImageURL = new URL(image, Astro.url);
     </>
   )
 }
+
+<slot name="head" />
 
 {/* Must be last: renders a <vercel-speed-insights> custom element that triggers implicit </head>, so anything after it ends up in <body>. */}
 <SpeedInsights />

--- a/src/layouts/AlbumLayout.astro
+++ b/src/layouts/AlbumLayout.astro
@@ -65,7 +65,9 @@ const headTitle = kind === 'travel' ? `${album.data.title} ${album.data.year}` :
       title={headTitle}
       description={album.data.description}
       image={`/og-image/photos/${album.id}.png`}
-    />
+    >
+      <link slot="head" rel="preconnect" href="https://photos.salolivares.com" />
+    </BaseHead>
   </head>
   <body>
     <AlbumHeader title={album.data.title} year={album.data.year} />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -69,7 +69,9 @@ const { title, description, image, articleDate, articleUpdatedDate } = Astro.pro
 
       window.localStorage.setItem('theme', theme);
     </script>
-    <BaseHead title={title} description={description} image={image} articleDate={articleDate} articleUpdatedDate={articleUpdatedDate} />
+    <BaseHead title={title} description={description} image={image} articleDate={articleDate} articleUpdatedDate={articleUpdatedDate}>
+      <slot name="head" slot="head" />
+    </BaseHead>
   </head>
   <body>
     <Header />

--- a/src/pages/photos/index.astro
+++ b/src/pages/photos/index.astro
@@ -33,6 +33,7 @@ const featuredImage = allImages[Math.floor(Math.random() * allImages.length)];
 ---
 
 <BaseLayout title="Photos">
+  <link slot="head" rel="preconnect" href="https://photos.salolivares.com" />
   <h1 class="sr-only">Photos</h1>
   <FeaturedImage image={featuredImage} class="mt-6" />
   <section class="mt-10">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,5 +1,4 @@
 @import 'tailwindcss';
-@import 'tw-animate-css';
 
 @plugin '@tailwindcss/typography';
 


### PR DESCRIPTION
Lighthouse flagged an unused preconnect to `photos.salolivares.com` on every page since only `/photos` and `/photos/[album]` actually fetch from there. Moved it out of the global `BaseHead` into a `<slot name="head">` and emit it from the photos routes only. Also dropped `tw-animate-css` which wasn't referenced anywhere.

Worth noting: also tried splitting prose styles into a route-scoped CSS chunk to shrink the homepage bundle, but Tailwind v4 + Astro's per-route CSS chunking flipped the cascade order between `.mb-1` and the typography plugin's `:where(h1)` rule, so prod and local rendered the title margin differently. Reverted that part. The preconnect change is the only behavioral win here.